### PR TITLE
chore: reduce dependabot noise (monthly, 1 PR per ecosystem)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,10 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     target-branch: main
     labels: [auto-dependencies]
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 1
     ignore:
       # major version bumps of arrow* and parquet are handled manually
       - dependency-name: "arrow*"
@@ -65,11 +65,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 1
     labels: [auto-dependencies]
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
     labels: [auto-dependencies]


### PR DESCRIPTION
## Summary
- Switch all three Dependabot ecosystems (cargo, github-actions, pip) from weekly to monthly
- Cap `open-pull-requests-limit` to 1 per ecosystem

This repo is a sandbox for CI testing, so we don't need a constant stream of dependency PRs.

## Test plan
- [ ] Dependabot picks up the new schedule on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)